### PR TITLE
Add monitoring script

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,5 @@ supervisord_supervisorctl_serverurl:  "unix://{{ supervisord_unix_http_server_so
 
 supervisord_include_path: "/etc/supervisor/conf.d"
 supervisord_include_files: "{{ supervisord_include_path }}/*.conf"
+
+supervisord_log_fatal_state_to_syslog: False

--- a/files/supervisor-fatals-listener.py
+++ b/files/supervisor-fatals-listener.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+import socket
+import sys
+import syslog
+
+from supervisor import childutils
+
+def payloaddata(payload):
+  return dict([ x.split(':') for x in payload.split() ])
+
+def main():
+  syslog.openlog(logoption=syslog.LOG_PID, facility=syslog.LOG_USER)
+  syslog.syslog(syslog.LOG_INFO, 'Monitoring supervisor FATALS')
+  hostname = socket.gethostname()
+
+  while True:
+    headers, payload = childutils.listener.wait()
+    payload = payloaddata(payload)
+
+    processname = payload['processname']
+    if (payload['groupname'] != payload['processname']):
+      processname = payload['groupname'] + '.' + processname
+
+    syslog.syslog(syslog.LOG_CRIT, '[SUPERVISOR] Process entered FATAL state: ' + processname)
+
+    childutils.listener.ok()
+
+if __name__ == '__main__':
+  main()

--- a/files/supervisor.event.listeners.conf
+++ b/files/supervisor.event.listeners.conf
@@ -1,0 +1,4 @@
+[eventlistener:fatal_state_to_syslog]
+command=/usr/local/bin/supervisor-fatals-listener.py
+events=PROCESS_STATE_FATAL
+stderr_logfile=syslog

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,14 @@
 - name: Create supervisord group
   group: name=supervisord system=yes state=present
 
+- name: Add the supervisor fatals events listener
+  copy: src=files/supervisor-fatals-listener.py mode=755 dest=/usr/local/bin/supervisor-fatals-listener.py
+  when: supervisord_log_fatal_state_to_syslog
+
+- name: Configure the supervisor fatals events listener
+  copy: src=files/supervisor.event.listeners.conf dest=/etc/supervisor/conf.d/eventlisteners.conf
+  when: supervisord_log_fatal_state_to_syslog
+
 - name: Create supervisord config
   template: src=supervisord.conf.j2 dest=/etc/supervisor/supervisord.conf
   register: supervisord_config_file


### PR DESCRIPTION
This feature adds the option of installing a monitoring script that listens to PROCESS_STATE_FATAL messages in supervisord, and sends those to the local syslog service.

The script is not installed by default, you have to enable it by setting:

`supervisord_log_fatal_state_to_syslog: True`